### PR TITLE
potential infinite loop ?

### DIFF
--- a/amqpstorm/heartbeat.py
+++ b/amqpstorm/heartbeat.py
@@ -58,10 +58,11 @@ class Heartbeat(object):
 
         :return:
         """
-        self._running.clear()
-        if self._timer:
-            self._timer.cancel()
-        self._timer = None
+        with self._lock:
+            self._running.clear()
+            if self._timer:
+                self._timer.cancel()
+            self._timer = None
 
     def _check_for_life_signs(self):
         """Check Connection for life signs.
@@ -75,9 +76,9 @@ class Heartbeat(object):
 
         :rtype: bool
         """
+        self._lock.acquire()
         if not self._running.is_set():
             return False
-        self._lock.acquire()
         try:
             if self._writes_since_check == 0:
                 self.send_heartbeat()

--- a/amqpstorm/heartbeat.py
+++ b/amqpstorm/heartbeat.py
@@ -102,7 +102,8 @@ class Heartbeat(object):
             self._reads_since_check = 0
             self._writes_since_check = 0
             self._lock.release()
-        self._start_new_timer()
+        if self._timer:
+            self._start_new_timer()
         return True
 
     def _start_new_timer(self):


### PR DESCRIPTION
Hello,

I am using your library in conjunction with celery and i regularly encounter a problem: When asking celery to restart its worker (emitting a SIGTERM), the process is blocked and celery doesn't want to restart. 
Celery maintains a parent thread that runs child threads where tasks are executed. Amqpstorm's thread is also run from this parent thread.
The processes in htop look like this:

![screenshot from 2017-04-11 10-34-26](https://cloud.githubusercontent.com/assets/5306537/24899955/80b61910-1ea2-11e7-94de-b3300db97799.png)

Here process 13880 & 13803 are related to amqpstorm. 13803 is the inbound_thread while 13880 is the heartbeat timer.

After some investigation, i found out that killing the thread responsible for the heartbeat timer allows celery to gracefuly restart... This lead me to think that the timer could possibly create a deadlock.

I have created a pull request based on this assumption and will try this branch on my setup: Can you tell me what you think of it ? Do you see any other possible explanations for the error i see ?