### PR TITLE
Added redelivered property to message

### DIFF
--- a/amqpstorm/message.py
+++ b/amqpstorm/message.py
@@ -313,6 +313,16 @@ class Message(BaseMessage):
         """
         self._update_properties('reply_to', value)
 
+    @property
+    def redelivered(self):
+        """Indicates if this message may have been delivered before (but not
+        acknowledged)"
+
+        :rtype: bool or None
+
+        """
+        return self._method['redelivered'] if self._method else None
+
     def json(self):
         """Deserialize the message body, if it is JSON.
 

--- a/amqpstorm/message.py
+++ b/amqpstorm/message.py
@@ -319,7 +319,6 @@ class Message(BaseMessage):
         acknowledged)"
 
         :rtype: bool or None
-
         """
         return self._method['redelivered'] if self._method else None
 

--- a/amqpstorm/tests/unit/message_tests.py
+++ b/amqpstorm/tests/unit/message_tests.py
@@ -114,6 +114,19 @@ class MessageTests(TestFramework):
 
         self.assertEqual(reply_to, message.reply_to)
 
+    def test_message_redelivered(self):
+        message = Message.create(None, '')
+
+        self.assertIsNone(message.redelivered)
+
+        message = Message.create(body='',
+                                 channel=FakeChannel())
+        message._method = {
+            'redelivered': True
+        }
+
+        self.assertEqual(message.redelivered, True)
+
     def test_message_do_not_override_properties(self):
         reply_to = self.message,
         correlation_id = str(uuid.uuid4())


### PR DESCRIPTION
It can be used for implementing retry logic or error handling when finding messages that have previously been rejected. In RabbitMQ 3.8 there are also plans to add support for a redelivered count.