### PR TITLE
Adding sasl external authentication

### DIFF
--- a/amqpstorm/channel0.py
+++ b/amqpstorm/channel0.py
@@ -146,8 +146,10 @@ class Channel0(object):
         mechanisms = try_utf8_decode(frame_in.mechanisms)
         if 'EXTERNAL' in mechanisms:
             mechanism = 'EXTERNAL'
+            credentials = '\0\0'
         elif 'PLAIN' in mechanisms:
             mechanism = 'PLAIN'
+            credentials = self._plain_credentials()
         else:
             exception = AMQPConnectionError(
                 'Unsupported Security Mechanism(s): %s' %
@@ -155,7 +157,6 @@ class Channel0(object):
             )
             self._connection.exceptions.append(exception)
             return
-        credentials = self._plain_credentials()
         start_ok_frame = specification.Connection.StartOk(
             mechanism=mechanism,
             client_properties=self._client_properties(),

--- a/amqpstorm/channel0.py
+++ b/amqpstorm/channel0.py
@@ -7,7 +7,6 @@ from pamqp import specification
 from pamqp.heartbeat import Heartbeat
 
 from amqpstorm import __version__
-from amqpstorm.base import AUTH_MECHANISM
 from amqpstorm.base import LOCALE
 from amqpstorm.base import MAX_CHANNELS
 from amqpstorm.base import MAX_FRAME_SIZE

--- a/amqpstorm/channel0.py
+++ b/amqpstorm/channel0.py
@@ -142,10 +142,14 @@ class Channel0(object):
         """Send Start OK frame.
 
         :param specification.Connection.Start frame_in: Amqp frame.
-
         :return:
         """
-        if 'PLAIN' not in try_utf8_decode(frame_in.mechanisms):
+        mechanisms = try_utf8_decode(frame_in.mechanisms)
+        if 'EXTERNAL' in mechanisms:
+            mechanism = 'EXTERNAL'
+        elif 'PLAIN' in mechanisms:
+            mechanism = 'PLAIN'
+        else:
             exception = AMQPConnectionError(
                 'Unsupported Security Mechanism(s): %s' %
                 frame_in.mechanisms
@@ -154,7 +158,7 @@ class Channel0(object):
             return
         credentials = self._plain_credentials()
         start_ok_frame = specification.Connection.StartOk(
-            mechanism=AUTH_MECHANISM,
+            mechanism=mechanism,
             client_properties=self._client_properties(),
             response=credentials,
             locale=LOCALE

--- a/amqpstorm/tests/unit/channel0/channel0_tests.py
+++ b/amqpstorm/tests/unit/channel0/channel0_tests.py
@@ -67,12 +67,26 @@ class Channel0Tests(TestFramework):
         self.assertTrue(connection.is_closed)
         self.assertRaises(AMQPConnectionError, connection.check_for_errors)
 
-    def test_channel0_send_start_ok(self):
+    def test_channel0_send_start_ok_plain(self):
         connection = FakeConnection()
         connection.parameters['username'] = 'guest'
         connection.parameters['password'] = 'password'
         channel = Channel0(connection)
         channel._send_start_ok(Connection.Start(mechanisms=b'PLAIN'))
+
+        self.assertTrue(connection.frames_out)
+
+        channel_id, frame_out = connection.frames_out.pop()
+
+        self.assertEqual(channel_id, 0)
+        self.assertIsInstance(frame_out, Connection.StartOk)
+        self.assertNotEqual(frame_out.locale, '')
+        self.assertIsNotNone(frame_out.locale)
+
+    def test_channel0_send_start_ok_external(self):
+        connection = FakeConnection()
+        channel = Channel0(connection)
+        channel._send_start_ok(Connection.Start(mechanisms=b'EXTERNAL'))
 
         self.assertTrue(connection.frames_out)
 


### PR DESCRIPTION
@eandersson 
AMQPStorm provides ssl connections.
Rabbitmq supports authentication by supplying ssl certificates without the need of using passwords.
Instead the certificate will be validated and the DN or CN ( common name ) of the certificate will be used as user name.
Rabbitmq is returning the list of supported authentications, in this case EXTERNAL, which is unfortunately not handled by your API, instead just PLAIN authentication with user and password is supported.
I have tried this using a certificate and could connect against my rabbitmq server.

Please have a look. I would like to see this being part of the main branch

Thanks

Bernd
