### PR TITLE
unknown tag extra_setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license='MIT License',
     url='https://www.amqpstorm.io',
     install_requires=['pamqp>=1.6.1,<2.0'],
-    extra_require={
+    extras_require={
         'management': ['requests']
     },
     package_data={'': ['README.rst', 'LICENSE', 'CHANGELOG.rst']},


### PR DESCRIPTION
@eandersson 
In setup.py the extra_setup tag causes a warning on installation using e.g. a tar gzipped version of your project.
/usr/lib/python3.4/distutils/dist.py:260: UserWarning: Unknown distribution option: 'extra_require'
This is a typo and should read
extras_setup
Please apply.
