### PR TITLE
Updated CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 language: python
 addons:
@@ -7,17 +7,21 @@ python:
   - 2.7
   - 3.5
   - 3.6
-  - 3.7-dev
+  - 3.7
   - nightly
 install:
-  - sudo rabbitmq-plugins enable rabbitmq_management
-  - sudo service rabbitmq-server restart
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt
 script: nosetests -v -l DEBUG --logging-level=DEBUG --with-coverage --cover-package=amqpstorm --with-timer --timer-top-n 10
+before_install:
+  - docker pull rabbitmq:management
+  - docker run -d --hostname travis --name travis -p 5672:5672 -p 15672:15672 rabbitmq:management
+  - sleep 10s
+  - nc localhost 5672 < /dev/null || exit 1
+  - nc localhost 15672 < /dev/null || exit 1
 before_script:
   - flake8 --ignore=F821 .
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 services:
-  - rabbitmq
+  - docker

--- a/amqpstorm/tests/unit/channel0/channel0_tests.py
+++ b/amqpstorm/tests/unit/channel0/channel0_tests.py
@@ -131,7 +131,7 @@ class Channel0Tests(TestFramework):
         self.assertEqual(channel.max_allowed_channels, MAX_CHANNELS)
 
     def test_channel0_send_tune_ok_negotiate_use_server(self):
-        """"Test to make sure that we use the highest acceptable value from
+        """Test to make sure that we use the highest acceptable value from
         the servers perspective.
         """
         channel = Channel0(FakeConnection())


### PR DESCRIPTION
- Use Docker to test against the latest version of RabbitMQ.
- Moved to xenial to allow us to properly test against Python 3.7.0 and 3.8 Alpha.
- Removed an unreliable test causing CI to fail too often.