### PR TITLE
Add ability to override client_properties in Connection

### DIFF
--- a/amqpstorm/channel0.py
+++ b/amqpstorm/channel0.py
@@ -20,7 +20,7 @@ LOGGER = logging.getLogger(__name__)
 class Channel0(object):
     """Internal Channel0 handler."""
 
-    def __init__(self, connection):
+    def __init__(self, connection, client_properties=None):
         super(Channel0, self).__init__()
         self.is_blocked = False
         self.max_allowed_channels = MAX_CHANNELS
@@ -29,6 +29,7 @@ class Channel0(object):
         self._connection = connection
         self._heartbeat = connection.parameters['heartbeat']
         self._parameters = connection.parameters
+        self._override_client_properties = client_properties
 
     def on_frame(self, frame_in):
         """Handle frames sent to Channel0.
@@ -214,13 +215,12 @@ class Channel0(object):
         self._connection.write_frame(0, frame_out)
         LOGGER.debug('Frame Sent: %s', frame_out.name)
 
-    @staticmethod
-    def _client_properties():
+    def _client_properties(self):
         """AMQPStorm Client Properties.
 
         :rtype: dict
         """
-        return {
+        client_properties = {
             'product': 'AMQPStorm',
             'platform': 'Python %s (%s)' % (platform.python_version(),
                                             platform.python_implementation()),
@@ -234,3 +234,6 @@ class Channel0(object):
             'information': 'See https://github.com/eandersson/amqpstorm',
             'version': __version__
         }
+        if self._override_client_properties:
+            client_properties.update(self._override_client_properties)
+        return client_properties

--- a/amqpstorm/connection.py
+++ b/amqpstorm/connection.py
@@ -44,6 +44,7 @@ class Connection(Stateful):
         :param int|float timeout: Socket timeout
         :param bool ssl: Enable SSL
         :param dict ssl_options: SSL kwargs (from ssl.wrap_socket)
+        :param dict client_properties: None or dict of client properties
         :param bool lazy: Lazy initialize the connection
 
         :raises AMQPConnectionError: Raises if the connection
@@ -61,12 +62,13 @@ class Connection(Stateful):
             'heartbeat': kwargs.get('heartbeat', DEFAULT_HEARTBEAT_INTERVAL),
             'timeout': kwargs.get('timeout', DEFAULT_SOCKET_TIMEOUT),
             'ssl': kwargs.get('ssl', False),
-            'ssl_options': kwargs.get('ssl_options', {})
+            'ssl_options': kwargs.get('ssl_options', {}),
+            'client_properties': kwargs.get('client_properties', {})
         }
         self._validate_parameters()
         self._io = IO(self.parameters, exceptions=self._exceptions,
                       on_read_impl=self._read_buffer)
-        self._channel0 = Channel0(self)
+        self._channel0 = Channel0(self, self.parameters['client_properties'])
         self._channels = {}
         self._last_channel_id = None
         self.heartbeat = Heartbeat(self.parameters['heartbeat'],

--- a/amqpstorm/tests/functional/management/connection_tests.py
+++ b/amqpstorm/tests/functional/management/connection_tests.py
@@ -70,7 +70,8 @@ class ApiConnectionFunctionalTests(TestFunctionalFramework):
         self.assertEqual(len(api.connection.list()), 0,
                          'found an open connection, test will fail')
 
-        connection = Connection(HOST, USERNAME, PASSWORD, timeout=1, client_properties={'platform': 'Atari', 'license': 'MIT'})
+        client_properties = {'platform': 'Atari', 'license': 'MIT'}
+        connection = Connection(HOST, USERNAME, PASSWORD, timeout=1, client_properties=client_properties)
 
         connections = retry_function_wrapper(api.connection.list)
 

--- a/amqpstorm/tests/functional/management/connection_tests.py
+++ b/amqpstorm/tests/functional/management/connection_tests.py
@@ -63,3 +63,22 @@ class ApiConnectionFunctionalTests(TestFunctionalFramework):
         self.assertEqual(len(api.connection.list()), 0)
 
         connection.close()
+
+    def test_api_connection_client_properties(self):
+        api = ManagementApi(HTTP_URL, USERNAME, PASSWORD, timeout=1)
+
+        self.assertEqual(len(api.connection.list()), 0,
+                         'found an open connection, test will fail')
+
+        connection = Connection(HOST, USERNAME, PASSWORD, timeout=1, client_properties={'platform': 'Atari', 'license': 'MIT'})
+
+        connections = retry_function_wrapper(api.connection.list)
+
+        self.assertIsNotNone(connections)
+
+        self.assertEqual(len(connections), 1)
+
+        for conn in api.connection.list():
+            self.assertEqual(conn['client_properties']['platform'], 'Atari')
+
+        connection.close()

--- a/amqpstorm/tests/functional/management/connection_tests.py
+++ b/amqpstorm/tests/functional/management/connection_tests.py
@@ -71,7 +71,8 @@ class ApiConnectionFunctionalTests(TestFunctionalFramework):
                          'found an open connection, test will fail')
 
         cp = {'platform': 'Atari', 'license': 'MIT'}
-        connection = Connection(HOST, USERNAME, PASSWORD, timeout=1, client_properties=cp)
+        connection = Connection(HOST, USERNAME, PASSWORD, timeout=1,
+                                client_properties=cp)
 
         connections = retry_function_wrapper(api.connection.list)
 

--- a/amqpstorm/tests/functional/management/connection_tests.py
+++ b/amqpstorm/tests/functional/management/connection_tests.py
@@ -70,8 +70,8 @@ class ApiConnectionFunctionalTests(TestFunctionalFramework):
         self.assertEqual(len(api.connection.list()), 0,
                          'found an open connection, test will fail')
 
-        client_properties = {'platform': 'Atari', 'license': 'MIT'}
-        connection = Connection(HOST, USERNAME, PASSWORD, timeout=1, client_properties=client_properties)
+        cp = {'platform': 'Atari', 'license': 'MIT'}
+        connection = Connection(HOST, USERNAME, PASSWORD, timeout=1, client_properties=cp)
 
         connections = retry_function_wrapper(api.connection.list)
 

--- a/amqpstorm/tests/unit/channel0/channel0_tests.py
+++ b/amqpstorm/tests/unit/channel0/channel0_tests.py
@@ -183,3 +183,20 @@ class Channel0Tests(TestFramework):
         )
 
         self.assertRaises(AMQPConnectionError, connection.check_for_errors)
+
+    def test_channel0_override_client_credentials(self):
+        channel = Channel0(FakeConnection(), {'platform': 'Atari', 'license': 'MIT'})
+        result = channel._client_properties()
+
+        information = 'See https://github.com/eandersson/amqpstorm'
+
+        self.assertIsInstance(result, dict)
+
+        self.assertTrue(result['capabilities']['authentication_failure_close'])
+        self.assertTrue(result['capabilities']['consumer_cancel_notify'])
+        self.assertTrue(result['capabilities']['publisher_confirms'])
+        self.assertTrue(result['capabilities']['connection.blocked'])
+        self.assertTrue(result['capabilities']['basic.nack'])
+        self.assertEqual(result['information'], information)
+        self.assertEqual(result['platform'], 'Atari')
+        self.assertEqual(result['license'], 'MIT')

--- a/amqpstorm/tests/unit/channel0/channel0_tests.py
+++ b/amqpstorm/tests/unit/channel0/channel0_tests.py
@@ -185,7 +185,8 @@ class Channel0Tests(TestFramework):
         self.assertRaises(AMQPConnectionError, connection.check_for_errors)
 
     def test_channel0_override_client_credentials(self):
-        channel = Channel0(FakeConnection(), {'platform': 'Atari', 'license': 'MIT'})
+        client_properties = {'platform': 'Atari', 'license': 'MIT'}
+        channel = Channel0(FakeConnection(), client_properties)
         result = channel._client_properties()
 
         information = 'See https://github.com/eandersson/amqpstorm'

--- a/amqpstorm/tests/unit/uri_connection/uri_connection_tests.py
+++ b/amqpstorm/tests/unit/uri_connection/uri_connection_tests.py
@@ -178,10 +178,10 @@ class UriConnectionTests(TestFramework):
         self.assertEqual(ssl_options['certfile'], 'file.crt')
 
     def test_uri_set_client_properties(self):
-        client_properties = {'platform': 'Atari', 'license': 'MIT'}
+        cp = {'platform': 'Atari', 'license': 'MIT'}
         connection = UriConnection(
-            'amqp://guest:guest@localhost:5672/%2F', lazy=True, client_properties=client_properties
+            'amqp://guest:guest@localhost:5672/%2F', lazy=True, client_properties=cp
         )
 
         self.assertIsInstance(connection.parameters['client_properties'], dict)
-        self.assertEqual(connection.parameters['client_properties'], client_properties)
+        self.assertEqual(connection.parameters['client_properties'], cp)

--- a/amqpstorm/tests/unit/uri_connection/uri_connection_tests.py
+++ b/amqpstorm/tests/unit/uri_connection/uri_connection_tests.py
@@ -176,3 +176,11 @@ class UriConnectionTests(TestFramework):
         self.assertEqual(ssl_options['ssl_version'], ssl.PROTOCOL_TLSv1)
         self.assertEqual(ssl_options['keyfile'], 'file.key')
         self.assertEqual(ssl_options['certfile'], 'file.crt')
+
+    def test_uri_set_client_properties(self):
+        connection = UriConnection(
+            'amqp://guest:guest@localhost:5672/%2F', lazy=True, client_properties={'platform': 'Atari', 'license': 'MIT'}
+        )
+
+        self.assertIsInstance(connection.parameters['client_properties'], dict)
+        self.assertEqual(connection.parameters['client_properties'], {'platform': 'Atari', 'license': 'MIT'})

--- a/amqpstorm/tests/unit/uri_connection/uri_connection_tests.py
+++ b/amqpstorm/tests/unit/uri_connection/uri_connection_tests.py
@@ -178,9 +178,10 @@ class UriConnectionTests(TestFramework):
         self.assertEqual(ssl_options['certfile'], 'file.crt')
 
     def test_uri_set_client_properties(self):
+        client_properties = {'platform': 'Atari', 'license': 'MIT'}
         connection = UriConnection(
-            'amqp://guest:guest@localhost:5672/%2F', lazy=True, client_properties={'platform': 'Atari', 'license': 'MIT'}
+            'amqp://guest:guest@localhost:5672/%2F', lazy=True, client_properties=client_properties
         )
 
         self.assertIsInstance(connection.parameters['client_properties'], dict)
-        self.assertEqual(connection.parameters['client_properties'], {'platform': 'Atari', 'license': 'MIT'})
+        self.assertEqual(connection.parameters['client_properties'], client_properties)

--- a/amqpstorm/tests/unit/uri_connection/uri_connection_tests.py
+++ b/amqpstorm/tests/unit/uri_connection/uri_connection_tests.py
@@ -180,7 +180,8 @@ class UriConnectionTests(TestFramework):
     def test_uri_set_client_properties(self):
         cp = {'platform': 'Atari', 'license': 'MIT'}
         connection = UriConnection(
-            'amqp://guest:guest@localhost:5672/%2F', lazy=True, client_properties=cp
+            'amqp://guest:guest@localhost:5672/%2F', lazy=True,
+            client_properties=cp
         )
 
         self.assertIsInstance(connection.parameters['client_properties'], dict)

--- a/amqpstorm/uri_connection.py
+++ b/amqpstorm/uri_connection.py
@@ -25,7 +25,7 @@ class UriConnection(Connection):
     """
     __slots__ = []
 
-    def __init__(self, uri, ssl_options=None, lazy=False):
+    def __init__(self, uri, ssl_options=None, client_properties=None, lazy=False):
         """
         :param str uri: AMQP Connection string
 
@@ -45,6 +45,7 @@ class UriConnection(Connection):
         kwargs = self._parse_uri_options(parsed_uri, use_ssl, ssl_options)
         super(UriConnection, self).__init__(hostname, username,
                                             password, port,
+                                            client_properties=client_properties,
                                             lazy=lazy,
                                             **kwargs)
 

--- a/amqpstorm/uri_connection.py
+++ b/amqpstorm/uri_connection.py
@@ -25,7 +25,8 @@ class UriConnection(Connection):
     """
     __slots__ = []
 
-    def __init__(self, uri, ssl_options=None, client_properties=None, lazy=False):
+    def __init__(self, uri, ssl_options=None, client_properties=None,
+                 lazy=False):
         """
         :param str uri: AMQP Connection string
 
@@ -45,7 +46,8 @@ class UriConnection(Connection):
         kwargs = self._parse_uri_options(parsed_uri, use_ssl, ssl_options)
         super(UriConnection, self).__init__(hostname, username,
                                             password, port,
-                                            client_properties=client_properties,
+                                            client_properties=
+                                            client_properties,
                                             lazy=lazy,
                                             **kwargs)
 

--- a/amqpstorm/uri_connection.py
+++ b/amqpstorm/uri_connection.py
@@ -44,12 +44,12 @@ class UriConnection(Connection):
         username = urlparse.unquote(parsed_uri.username or 'guest')
         password = urlparse.unquote(parsed_uri.password or 'guest')
         kwargs = self._parse_uri_options(parsed_uri, use_ssl, ssl_options)
-        super(UriConnection, self).__init__(hostname, username,
-                                            password, port,
-                                            client_properties=
-                                            client_properties,
-                                            lazy=lazy,
-                                            **kwargs)
+        super(UriConnection, self).__init__(
+            hostname, username, password, port,
+            client_properties=client_properties,
+            lazy=lazy,
+            **kwargs
+        )
 
     def _parse_uri_options(self, parsed_uri, use_ssl=False, ssl_options=None):
         """Parse the uri options.


### PR DESCRIPTION
It would be useful to be able to override the client_properties that is sent when the Connection is made. This pull request adds an optional argument to Connection and UriConnection where you can pass in a dict. The default client properties is updated with this dict to come up with the client properties to send to RabbitMQ.