### PR TITLE
use the secure and non-deprecated way of creating TLS sockets

### DIFF
--- a/amqpstorm/io.py
+++ b/amqpstorm/io.py
@@ -228,7 +228,8 @@ class IO(object):
         hostname = self._parameters['hostname']
         context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.verify_mode = ssl.CERT_REQUIRED
-        context.check_hostname = True
+        check = self._parameters['ssl_options'].get('check_hostname', False)
+        context.check_hostname = check
         context.load_default_certs()
         return context.wrap_socket(sock, do_handshake_on_connect=True,
                                    server_hostname=hostname)

--- a/amqpstorm/io.py
+++ b/amqpstorm/io.py
@@ -225,14 +225,13 @@ class IO(object):
                 sock, do_handshake_on_connect=True,
                 server_hostname=hostname
             )
-        if 'ssl_version' not in self._parameters['ssl_options']:
-            self._parameters['ssl_options']['ssl_version'] = (
-                compatibility.DEFAULT_SSL_VERSION
-            )
-        return ssl.wrap_socket(
-            sock, do_handshake_on_connect=True,
-            **self._parameters['ssl_options']
-        )
+        hostname = self._parameters['hostname']
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.check_hostname = True
+        context.load_default_certs()
+        return context.wrap_socket(sock, do_handshake_on_connect=True,
+                                   server_hostname=hostname)
 
     def _create_inbound_thread(self):
         """Internal Thread that handles all incoming traffic.

--- a/amqpstorm/io.py
+++ b/amqpstorm/io.py
@@ -227,7 +227,11 @@ class IO(object):
             )
         hostname = self._parameters['hostname']
         context = ssl.SSLContext(ssl.PROTOCOL_TLS)
-        context.verify_mode = ssl.CERT_REQUIRED
+        mode = self._parameters['ssl_options'].get('verify_mode', 'none')
+        if mode.lower() == 'required':
+            context.verify_mode = ssl.CERT_REQUIRED
+        else:
+            context.verify_mode = ssl.CERT_NONE
         check = self._parameters['ssl_options'].get('check_hostname', False)
         context.check_hostname = check
         context.load_default_certs()

--- a/amqpstorm/tests/unit/io/io_tests.py
+++ b/amqpstorm/tests/unit/io/io_tests.py
@@ -4,7 +4,6 @@ import ssl
 from mock import Mock
 
 import amqpstorm.io
-from amqpstorm import compatibility
 from amqpstorm.exception import AMQPConnectionError
 from amqpstorm.io import IO
 from amqpstorm.tests.utility import FakeConnection

--- a/amqpstorm/tests/unit/io/io_tests.py
+++ b/amqpstorm/tests/unit/io/io_tests.py
@@ -61,7 +61,6 @@ class IOTests(TestFramework):
             self.assertIsInstance(sock, socket.socket)
         if hasattr(ssl, 'SSLSocket'):
             self.assertIsInstance(sock, ssl.SSLSocket)
-        self.assertTrue(connection.parameters['ssl_options']['ssl_version'])
 
     def test_io_get_socket_address(self):
         connection = FakeConnection()
@@ -114,32 +113,6 @@ class IOTests(TestFramework):
             'connection/socket error',
             connection.check_for_errors
         )
-
-    def test_io_sets_default_ssl_version(self):
-        connection = FakeConnection()
-        connection.parameters['ssl_options'] = {}
-
-        sock = Mock(name='socket', spec=socket.socket)
-        sock.fileno.return_value = 1
-
-        io = IO(connection.parameters)
-        self.assertRaises(Exception, io._ssl_wrap_socket, sock)
-        self.assertEqual(connection.parameters['ssl_options']['ssl_version'],
-                         compatibility.DEFAULT_SSL_VERSION)
-
-    def test_io_use_defined_ssl_version(self):
-        connection = FakeConnection()
-        connection.parameters['ssl_options'] = {
-            'ssl_version': 'travis-ci'
-        }
-
-        sock = Mock(name='socket', spec=socket.socket)
-        sock.fileno.return_value = 1
-
-        io = IO(connection.parameters)
-        self.assertRaises(Exception, io._ssl_wrap_socket, sock)
-        self.assertEqual(connection.parameters['ssl_options']['ssl_version'],
-                         'travis-ci')
 
     def test_io_set_ssl_context(self):
         connection = FakeConnection()


### PR DESCRIPTION
And enable SNI by default, which is required for AMQP servers
behind a TLS terminator/LB

https://docs.python.org/3/library/ssl.html#socket-creation