### PR TITLE
Retry on SSLWantReadErrors

### DIFF
--- a/amqpstorm/compatibility.py
+++ b/amqpstorm/compatibility.py
@@ -29,6 +29,16 @@ if PYTHON3:
 else:
     RANGE = xrange
 
+
+class DummyException(Exception):
+    """
+    Never raised by anything.
+
+    This is used in except blocks if the intended
+    exception cannot be imported.
+    """
+
+
 SSL_CERT_MAP = {}
 SSL_VERSIONS = {}
 SSL_OPTIONS = [
@@ -69,6 +79,9 @@ if SSL_SUPPORTED:
         'cert_optional': ssl.CERT_OPTIONAL,
         'cert_required': ssl.CERT_REQUIRED
     }
+    SSLWantReadError = ssl.SSLWantReadError
+else:
+    SSLWantReadError = DummyException
 
 
 def is_string(obj):

--- a/amqpstorm/io.py
+++ b/amqpstorm/io.py
@@ -272,6 +272,10 @@ class IO(object):
             data_in = self._read_from_socket()
         except socket.timeout:
             pass
+        except compatibility.SSLWantReadError:
+            # NOTE(visobet): Retry if the non-blocking socket does not
+            # have any meaningful data ready.
+            pass
         except (IOError, OSError) as why:
             if why.args[0] not in (EWOULDBLOCK, EAGAIN):
                 self._exceptions.append(AMQPConnectionError(why))

--- a/amqpstorm/io.py
+++ b/amqpstorm/io.py
@@ -279,6 +279,8 @@ class IO(object):
         except (IOError, OSError) as why:
             if why.args[0] not in (EWOULDBLOCK, EAGAIN):
                 self._exceptions.append(AMQPConnectionError(why))
+                if self._running.is_set():
+                    LOGGER.warning("Stopping inbound thread due to %s", why)
                 self._running.clear()
         return data_in
 

--- a/amqpstorm/tests/unit/io/io_exception_tests.py
+++ b/amqpstorm/tests/unit/io/io_exception_tests.py
@@ -36,6 +36,15 @@ class IOExceptionTests(TestFramework):
             connection.check_for_errors
         )
 
+    def test_io_receive_raises_ssl_want_read_error(self):
+        connection = FakeConnection()
+
+        io = IO(connection.parameters, exceptions=connection.exceptions)
+        io.socket = mock.Mock(name='socket', spec=socket.socket)
+        io.socket.recv.side_effect = compatibility.SSLWantReadError()
+        io._receive()
+        self.assertIsNone(connection.check_for_errors())
+
     def test_io_receive_does_not_raise_on_block(self):
         connection = FakeConnection()
 

--- a/amqpstorm/tests/unit/io/io_exception_tests.py
+++ b/amqpstorm/tests/unit/io/io_exception_tests.py
@@ -60,6 +60,7 @@ class IOExceptionTests(TestFramework):
         io.socket = mock.Mock(name='socket', spec=socket.socket)
         io.socket.recv.side_effect = socket.timeout('timeout')
         io._receive()
+        self.assertIsNone(connection.check_for_errors())
 
     def test_io_simple_send_with_error(self):
         connection = FakeConnection()

--- a/amqpstorm/tests/unit/io/io_tests.py
+++ b/amqpstorm/tests/unit/io/io_tests.py
@@ -11,6 +11,7 @@ from amqpstorm.tests.utility import TestFramework
 
 
 class IOTests(TestFramework):
+
     def test_io_socket_close(self):
         connection = FakeConnection()
         io = IO(connection.parameters)


### PR DESCRIPTION
I do not know enough about SSL to be sure that the proposed change is correct, but it seems that SSLWantReadErrors should be skipped in _receive:

We experienced the following error (which for some reason was hidden until we added additional logging to the amqpstorm library):

```
Traceback (most recent call last):
  File "python2.7/site-packages/amqpstorm/io.py", line 273, in _receive
    data_in = self._read_from_socket()
  File "python2.7/site-packages/amqpstorm/io.py", line 290, in _read_from_socket
    data_in = self.socket.read(FRAME_MAX)
  File "/python2.7/ssl.py", line 653, in read
    v = self._sslobj.read(len)
SSLWantReadError: The operation did not complete (read) (_ssl.c:1864)
```

Now I am not entirely sure if I understand https://bugs.python.org/issue12343 correctly, but it seems to advise on retrying the read on such errors.

According to the documentation, the SSLWantReadError is a subclass of IOError with an error code based on the openssl library. On our systems it is 2 (ENOENT, No entity).

Would ignoring this exception as proposed be the correct behavior?