### PR TITLE
Updated SSL example for new ssl_options keywords

### DIFF
--- a/amqpstorm/connection.py
+++ b/amqpstorm/connection.py
@@ -43,7 +43,9 @@ class Connection(Stateful):
         import amqpstorm
         ssl_options = {
             'context': ssl.create_default_context(cafile='cacert.pem'),
-            'server_hostname': 'rmq.eandersson.net'
+            'server_hostname': 'rmq.eandersson.net',
+            'check_hostname': True,        # New 2.8.0, default is False
+            'verify_mode': 'required',     # New 2.8.0, default is 'none'
         }
         connection = amqpstorm.Connection(
             'rmq.eandersson.net', 'guest', 'guest', port=5671,


### PR DESCRIPTION
Minor documentation update, you may have a cleaner way, but until I was reviewing code I didn't realize the SSL certificate validation check and hostname check were disabled by default.   

Reading through the related pull request, I understand the reasoning, but this at least makes it clear on the connection SSL/TLS example what the defaults are and how to override them.