### PR TITLE
Support alternate Message implemetation

### DIFF
--- a/amqpstorm/basic.py
+++ b/amqpstorm/basic.py
@@ -87,7 +87,7 @@ class Basic(Handler):
         get_frame = specification.Basic.Get(queue=queue,
                                             no_ack=no_ack)
         with self._channel.lock and self._channel.rpc.lock:
-            message = self._get_message(get_frame, auto_decode=auto_decode,  
+            message = self._get_message(get_frame, auto_decode=auto_decode,
                                         message_impl=message_impl)
             if message and to_dict:
                 return message.to_dict()

--- a/amqpstorm/basic.py
+++ b/amqpstorm/basic.py
@@ -80,13 +80,14 @@ class Basic(Handler):
                                    "set to consume")
         if message_impl:
             if not issubclass(message_impl, BaseMessage):
-                raiseAMQPInvalidArgument('message_impl should be derived from BaseMessage')
+                raiseAMQPInvalidArgument('message_impl should be derived " \
+                       "from BaseMessage')
         else:
             message_impl = Message
         get_frame = specification.Basic.Get(queue=queue,
                                             no_ack=no_ack)
         with self._channel.lock and self._channel.rpc.lock:
-            message = self._get_message(get_frame, auto_decode=auto_decode,  \
+            message = self._get_message(get_frame, auto_decode=auto_decode,  
                                         message_impl=message_impl)
             if message and to_dict:
                 return message.to_dict()
@@ -379,10 +380,10 @@ class Basic(Handler):
         finally:
             self._channel.rpc.remove(message_uuid)
         return message_impl(channel=self._channel,
-                       body=body,
-                       method=dict(get_ok_frame),
-                       properties=dict(content_header.properties),
-                       auto_decode=auto_decode)
+                            body=body,
+                            method=dict(get_ok_frame),
+                            properties=dict(content_header.properties),
+                            auto_decode=auto_decode)
 
     def _publish_confirm(self, frames_out, mandatory):
         """Confirm that message was published successfully.

--- a/amqpstorm/basic.py
+++ b/amqpstorm/basic.py
@@ -79,7 +79,7 @@ class Basic(Handler):
             raise AMQPChannelError("Cannot call 'get' when channel is "
                                    "set to consume")
         if message_impl:
-            if not isinstance(message_impl, BaseMessage):
+            if not issubclass(message_impl, BaseMessage):
                 raiseAMQPInvalidArgument('message_impl should be derived from BaseMessage')
         else:
             message_impl = Message

--- a/amqpstorm/basic.py
+++ b/amqpstorm/basic.py
@@ -9,6 +9,7 @@ from pamqp import specification
 
 from amqpstorm import compatibility
 from amqpstorm.base import Handler
+from amqpstorm.base import BaseMessage
 from amqpstorm.base import MAX_FRAME_SIZE
 from amqpstorm.exception import AMQPChannelError
 from amqpstorm.exception import AMQPInvalidArgument
@@ -50,7 +51,8 @@ class Basic(Handler):
                                             global_=global_)
         return self._channel.rpc_request(qos_frame)
 
-    def get(self, queue='', no_ack=False, to_dict=False, auto_decode=True):
+    def get(self, queue='', no_ack=False, to_dict=False, auto_decode=True,
+            message_impl=None):
         """Fetch a single message.
 
         :param str queue: Queue name
@@ -58,7 +60,7 @@ class Basic(Handler):
         :param bool to_dict: Should incoming messages be converted to a
                     dictionary before delivery.
         :param bool auto_decode: Auto-decode strings when possible.
-
+        :param class message_impl: Message implementation based on BaseMessage
         :raises AMQPInvalidArgument: Invalid Parameters
         :raises AMQPChannelError: Raises if the channel encountered an error.
         :raises AMQPConnectionError: Raises if the connection
@@ -76,10 +78,16 @@ class Basic(Handler):
         elif self._channel.consumer_tags:
             raise AMQPChannelError("Cannot call 'get' when channel is "
                                    "set to consume")
+        if message_impl:
+            if not isinstance(message_impl, BaseMessage):
+                raiseAMQPInvalidArgument('message_impl should be derived from BaseMessage')
+        else:
+            message_impl = Message
         get_frame = specification.Basic.Get(queue=queue,
                                             no_ack=no_ack)
         with self._channel.lock and self._channel.rpc.lock:
-            message = self._get_message(get_frame, auto_decode=auto_decode)
+            message = self._get_message(get_frame, auto_decode=auto_decode,  \
+                                        message_impl=message_impl)
             if message and to_dict:
                 return message.to_dict()
             return message
@@ -344,11 +352,12 @@ class Basic(Handler):
             body = bytes(body, encoding=encoding)
         return body
 
-    def _get_message(self, get_frame, auto_decode):
+    def _get_message(self, get_frame, auto_decode, message_impl):
         """Get and return a message using a Basic.Get frame.
 
         :param Basic.Get get_frame:
         :param bool auto_decode: Auto-decode strings when possible.
+        :param class message_impl: Message implementation based on BaseMessage
 
         :rtype: Message
         """
@@ -369,7 +378,7 @@ class Basic(Handler):
                                           content_header.body_size)
         finally:
             self._channel.rpc.remove(message_uuid)
-        return Message(channel=self._channel,
+        return message_impl(channel=self._channel,
                        body=body,
                        method=dict(get_ok_frame),
                        properties=dict(content_header.properties),

--- a/amqpstorm/channel.py
+++ b/amqpstorm/channel.py
@@ -148,7 +148,7 @@ class Channel(BaseChannel):
         """
         self.check_for_errors()
         if message_impl:
-            if not isinstance(message_impl, BaseMessage):
+            if not issubclass(message_impl, BaseMessage):
                 raise AMQPInvalidArgument('message_impl must derive from BaseMessage')
         else:
             message_impl = Message

--- a/amqpstorm/channel.py
+++ b/amqpstorm/channel.py
@@ -149,11 +149,13 @@ class Channel(BaseChannel):
         self.check_for_errors()
         if message_impl:
             if not issubclass(message_impl, BaseMessage):
-                raise AMQPInvalidArgument('message_impl must derive from BaseMessage')
+                raise AMQPInvalidArgument('message_impl must derive " \
+                      "from BaseMessage')
         else:
             message_impl = Message
         while not self.is_closed:
-            message = self._build_message(auto_decode=auto_decode, message_impl=message_impl)
+            message = self._build_message(auto_decode=auto_decode, 
+                                          message_impl=message_impl)
             if not message:
                 self.check_for_errors()
                 sleep(IDLE_WAIT)
@@ -449,10 +451,10 @@ class Channel(BaseChannel):
             body = self._build_message_body(content_header.body_size)
 
         message = message_impl(channel=self,
-                          body=body,
-                          method=dict(basic_deliver),
-                          properties=dict(content_header.properties),
-                          auto_decode=auto_decode)
+                               body=body,
+                               method=dict(basic_deliver),
+                               properties=dict(content_header.properties),
+                               auto_decode=auto_decode)
         return message
 
     def _build_message_headers(self):

--- a/amqpstorm/channel.py
+++ b/amqpstorm/channel.py
@@ -154,7 +154,7 @@ class Channel(BaseChannel):
         else:
             message_impl = Message
         while not self.is_closed:
-            message = self._build_message(auto_decode=auto_decode, 
+            message = self._build_message(auto_decode=auto_decode,
                                           message_impl=message_impl)
             if not message:
                 self.check_for_errors()

--- a/amqpstorm/connection.py
+++ b/amqpstorm/connection.py
@@ -43,7 +43,9 @@ class Connection(Stateful):
         import amqpstorm
         ssl_options = {
             'context': ssl.create_default_context(cafile='cacert.pem'),
-            'server_hostname': 'rmq.eandersson.net'
+            'server_hostname': 'rmq.eandersson.net',
+            'check_hostname': True,        # New 2.8.0, default is False
+            'verify_mode': 'required',     # New 2.8.0, default is 'none'
         }
         connection = amqpstorm.Connection(
             'rmq.eandersson.net', 'guest', 'guest', port=5671,

--- a/amqpstorm/tests/unit/basic/basic_tests.py
+++ b/amqpstorm/tests/unit/basic/basic_tests.py
@@ -8,6 +8,7 @@ from pamqp import specification
 from pamqp.body import ContentBody
 from pamqp.header import ContentHeader
 
+from amqpstorm import Message
 from amqpstorm.channel import Basic
 from amqpstorm.channel import Channel
 from amqpstorm.compatibility import RANGE
@@ -288,7 +289,7 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=False)
+        result = basic._get_message(get_frame, auto_decode=False, message_impl=Message)
 
         self.assertEqual(result.body, message)
 
@@ -309,7 +310,7 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=True)
+        result = basic._get_message(get_frame, auto_decode=True, message_impl=Message)
 
         self.assertEqual(result.body.encode('utf-8'), message)
 
@@ -325,7 +326,7 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=False)
+        result = basic._get_message(get_frame, auto_decode=False, message_impl=Message)
 
         self.assertEqual(result, None)
 

--- a/amqpstorm/tests/unit/basic/basic_tests.py
+++ b/amqpstorm/tests/unit/basic/basic_tests.py
@@ -289,7 +289,7 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=False, 
+        result = basic._get_message(get_frame, auto_decode=False,
                                     message_impl=Message)
 
         self.assertEqual(result.body, message)
@@ -311,7 +311,7 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=True, 
+        result = basic._get_message(get_frame, auto_decode=True,
                                     message_impl=Message)
 
         self.assertEqual(result.body.encode('utf-8'), message)
@@ -328,7 +328,7 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=False, 
+        result = basic._get_message(get_frame, auto_decode=False,
                                     message_impl=Message)
 
         self.assertEqual(result, None)

--- a/amqpstorm/tests/unit/basic/basic_tests.py
+++ b/amqpstorm/tests/unit/basic/basic_tests.py
@@ -289,7 +289,8 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=False, message_impl=Message)
+        result = basic._get_message(get_frame, auto_decode=False, 
+                                    message_impl=Message)
 
         self.assertEqual(result.body, message)
 
@@ -310,7 +311,8 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=True, message_impl=Message)
+        result = basic._get_message(get_frame, auto_decode=True, 
+                                    message_impl=Message)
 
         self.assertEqual(result.body.encode('utf-8'), message)
 
@@ -326,7 +328,8 @@ class BasicTests(TestFramework):
         channel.set_state(Channel.OPEN)
         basic = Basic(channel)
 
-        result = basic._get_message(get_frame, auto_decode=False, message_impl=Message)
+        result = basic._get_message(get_frame, auto_decode=False, 
+                                    message_impl=Message)
 
         self.assertEqual(result, None)
 

--- a/amqpstorm/tests/unit/channel/channel_message_handling_tests.py
+++ b/amqpstorm/tests/unit/channel/channel_message_handling_tests.py
@@ -24,7 +24,8 @@ class ChannelBuildMessageTests(TestFramework):
         body = ContentBody(value=message)
 
         channel._inbound = [deliver, header, body]
-        result = channel._build_message(auto_decode=False, message_impl=Message)
+        result = channel._build_message(auto_decode=False, 
+                                        message_impl=Message)
 
         self.assertIsInstance(result.body, bytes)
         self.assertEqual(result.body, message)

--- a/amqpstorm/tests/unit/channel/channel_message_handling_tests.py
+++ b/amqpstorm/tests/unit/channel/channel_message_handling_tests.py
@@ -24,7 +24,7 @@ class ChannelBuildMessageTests(TestFramework):
         body = ContentBody(value=message)
 
         channel._inbound = [deliver, header, body]
-        result = channel._build_message(auto_decode=False)
+        result = channel._build_message(auto_decode=False, message_impl=Message)
 
         self.assertIsInstance(result.body, bytes)
         self.assertEqual(result.body, message)
@@ -40,7 +40,7 @@ class ChannelBuildMessageTests(TestFramework):
         body = ContentBody(value=message)
 
         channel._inbound = [deliver, header, body]
-        result = channel._build_message(auto_decode=True)
+        result = channel._build_message(auto_decode=True, message_impl=Message)
 
         self.assertIsInstance(result.body, str)
         self.assertEqual(result.body, message.decode('utf-8'))
@@ -55,7 +55,7 @@ class ChannelBuildMessageTests(TestFramework):
         header = ContentHeader(body_size=message_len)
 
         channel._inbound = [deliver, deliver, header]
-        result = channel._build_message(auto_decode=True)
+        result = channel._build_message(auto_decode=True, message_impl=Message)
 
         self.assertEqual(result, None)
         self.assertIn("Received an out-of-order frame:",
@@ -72,7 +72,7 @@ class ChannelBuildMessageTests(TestFramework):
         body = ContentBody(value=message)
 
         channel._inbound = [header, deliver, header, body]
-        result = channel._build_message(auto_decode=True)
+        result = channel._build_message(auto_decode=True, message_impl=Message)
 
         self.assertEqual(result, None)
         self.assertIn("Received an out-of-order frame:",

--- a/amqpstorm/tests/unit/channel/channel_message_handling_tests.py
+++ b/amqpstorm/tests/unit/channel/channel_message_handling_tests.py
@@ -24,7 +24,7 @@ class ChannelBuildMessageTests(TestFramework):
         body = ContentBody(value=message)
 
         channel._inbound = [deliver, header, body]
-        result = channel._build_message(auto_decode=False, 
+        result = channel._build_message(auto_decode=False,
                                         message_impl=Message)
 
         self.assertIsInstance(result.body, bytes)


### PR DESCRIPTION
Adds support to basic.py/channel/get and channel/build_inbound_message to all specification of an alternate Message class, derived from BaseMessage, for the creation of messages read.

I was not sure the best way to implement test case(s) for an alternate Message implementation, so there are no test cases submitted at this time.
