### PR TITLE
Handle all channel opening within the lock

### DIFF
--- a/amqpstorm/connection.py
+++ b/amqpstorm/connection.py
@@ -189,10 +189,9 @@ class Connection(Stateful):
             self._channels[channel_id] = channel
             if not lazy:
                 channel.open()
-
-        channel.on_close_impl = self._cleanup_channel
-        LOGGER.debug('Channel #%d Opened', channel_id)
-        return self._channels[channel_id]
+            channel.on_close_impl = self._cleanup_channel
+            LOGGER.debug('Channel #%d Opened', channel_id)
+            return self._channels[channel_id]
 
     def check_for_errors(self):
         """Check Connection for errors.


### PR DESCRIPTION
Moved both the `_cleanup_channel` and `return` under the thread lock. We can't have the channel being cleaned up before the function return, as it will result in a `KeyError`, but we need to return a channel to not break the context manager.