### PR TITLE
use port 5671 when use_ssl=True

### DIFF
--- a/amqpstorm/tests/unit/uri_connection/test_uri_connection.py
+++ b/amqpstorm/tests/unit/uri_connection/test_uri_connection.py
@@ -83,11 +83,11 @@ class UriConnectionTests(TestFramework):
 
     def test_uri_set_port(self):
         connection = UriConnection(
-            'amqps://guest:guest@localhost:5672/%2F', lazy=True
+            'amqps://guest:guest@localhost:9999/%2F', lazy=True
         )
 
         self.assertIsInstance(connection.parameters['port'], int)
-        self.assertEqual(connection.parameters['port'], 5672)
+        self.assertEqual(connection.parameters['port'], 9999)
 
     def test_uri_set_heartbeat(self):
         connection = UriConnection(

--- a/amqpstorm/tests/unit/uri_connection/test_uri_connection.py
+++ b/amqpstorm/tests/unit/uri_connection/test_uri_connection.py
@@ -25,6 +25,19 @@ class UriConnectionTests(TestFramework):
                          DEFAULT_SOCKET_TIMEOUT)
         self.assertFalse(connection.parameters['ssl'])
 
+    def test_uri_default_port(self):
+        connection = UriConnection(
+            'amqp://guest:guest@localhost/%2F', lazy=True
+        )
+
+        self.assertEqual(connection.parameters['port'], 5672)
+
+        connection = UriConnection(
+            'amqps://guest:guest@localhost/%2F', lazy=True
+        )
+
+        self.assertEqual(connection.parameters['port'], 5671)
+
     def test_uri_ssl(self):
         connection = UriConnection(
             'amqps://guest:guest@localhost:5672/%2F', lazy=True

--- a/amqpstorm/uri_connection.py
+++ b/amqpstorm/uri_connection.py
@@ -58,7 +58,7 @@ class UriConnection(Connection):
         parsed_uri = urlparse.urlparse(uri)
         use_ssl = parsed_uri.scheme == 'amqps' or parsed_uri.scheme == 'https'
         hostname = parsed_uri.hostname or 'localhost'
-        port = parsed_uri.port or 5672
+        port = parsed_uri.port or (5671 if use_ssl else 5672)
         username = urlparse.unquote(parsed_uri.username or 'guest')
         password = urlparse.unquote(parsed_uri.password or 'guest')
         kwargs = self._parse_uri_options(parsed_uri, use_ssl, ssl_options)


### PR DESCRIPTION
Hello,

As per the AMQP spec, connection should be established on port 5671 when using amqps. Therefore I propose this pull request to make 5671 the default port when using ssl.

Thank you for the great library and have a nice day.