### PR TITLE
Use getlocale instead of getdefaultlocale

### DIFF
--- a/amqpstorm/base.py
+++ b/amqpstorm/base.py
@@ -7,7 +7,7 @@ from amqpstorm.exception import AMQPChannelError
 
 AUTH_MECHANISM = 'PLAIN'
 IDLE_WAIT = 0.01
-LOCALE = locale.getdefaultlocale()[0] or 'en_US'
+LOCALE = locale.getlocale()[0] or 'en_US'
 MAX_FRAME_SIZE = 131072
 MAX_CHANNELS = 65535
 


### PR DESCRIPTION
getdefaultlocale is deprecated in newer versions of Python.