### PR TITLE
Protect against a race condition in channel [#132]

### DIFF
--- a/amqpstorm/channel.py
+++ b/amqpstorm/channel.py
@@ -321,6 +321,8 @@ class Channel(BaseChannel):
         for message in self.build_inbound_messages(break_on_empty=True,
                                                    auto_decode=auto_decode):
             consumer_tag = message._method.get('consumer_tag')
+            if consumer_tag not in self._consumer_callbacks:
+                continue
             if to_tuple:
                 # noinspection PyCallingNonCallable
                 self._consumer_callbacks[consumer_tag](*message.to_tuple())

--- a/amqpstorm/tests/unit/channel/test_channel_message_handling.py
+++ b/amqpstorm/tests/unit/channel/test_channel_message_handling.py
@@ -390,6 +390,31 @@ class ChannelProcessDataEventTests(TestFramework):
         self.assertIsInstance(properties, dict)
         self.assertEqual(body, message)
 
+    def test_channel_process_data_events_no_callback_yet(self):
+        self.msg = None
+
+        channel = Channel(0, FakeConnection(), 360)
+        channel.set_state(channel.OPEN)
+
+        message = self.message.encode('utf-8')
+        message_len = len(message)
+
+        deliver = specification.Basic.Deliver(consumer_tag='travis-ci')
+        header = ContentHeader(body_size=message_len)
+        body = ContentBody(value=message)
+
+        channel._inbound = [deliver, header, body]
+
+        def callback(msg):
+            self.msg = msg
+
+        channel._consumer_callbacks['fake'] = callback
+
+        # We should not raise when the callback isn't set yet.
+        channel.process_data_events()
+
+        self.assertIsNone(self.msg)
+
 
 class ChannelStartConsumingTests(TestFramework):
     def test_channel_start_consuming(self):


### PR DESCRIPTION
It's safe to start processing events even if the consumer tag isn't set yet.