### PR TITLE
Add global random seed for deterministic tests

### DIFF
--- a/amqpstorm/tests/unit/basic/test_basic.py
+++ b/amqpstorm/tests/unit/basic/test_basic.py
@@ -17,6 +17,7 @@ from amqpstorm.tests.utility import FakeConnection
 from amqpstorm.tests.utility import TestFramework
 from amqpstorm.tests.utility import unittest
 
+random.seed(42)
 
 class BasicTests(TestFramework):
     def test_basic_qos(self):

--- a/amqpstorm/tests/unit/basic/test_basic.py
+++ b/amqpstorm/tests/unit/basic/test_basic.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import random
 import string
 import sys
 
@@ -17,7 +16,6 @@ from amqpstorm.tests.utility import FakeConnection
 from amqpstorm.tests.utility import TestFramework
 from amqpstorm.tests.utility import unittest
 
-random.seed(42)
 
 class BasicTests(TestFramework):
     def test_basic_qos(self):
@@ -239,7 +237,7 @@ class BasicTests(TestFramework):
 
     def test_basic_create_content_body_growing(self):
         basic = Basic(None)
-        long_string = ''.join(random.choice(string.ascii_letters)
+        long_string = ''.join(self.random.choice(string.ascii_letters)
                               for _ in RANGE(32768))
 
         for index in RANGE(32768):

--- a/amqpstorm/tests/utility.py
+++ b/amqpstorm/tests/utility.py
@@ -3,6 +3,7 @@ import uuid
 
 from amqpstorm.connection import Channel
 from amqpstorm.connection import Connection
+import random
 
 try:
     import unittest2 as unittest
@@ -173,6 +174,7 @@ class TestFramework(unittest.TestCase):
     message = str(uuid.uuid4())
 
     def __init__(self, *args, **kwargs):
+        self.random = random.Random(42)
         self.channel = None
         self.connection = None
         self.validate_logging = True


### PR DESCRIPTION
### Description

This PR introduces a global random seed set after imports in the test file. This change aims to make the tests more deterministic and easier to debug by ensuring consistent random behavior across test runs.

### Current Issues (Before this PR):

The tests currently use random without setting a fixed seed, which causes several problems :

a. Flaky Tests: Tests sometimes pass and sometimes fail due to different random values;
b. Hard to Reproduce: When a test fails, it's difficult to reproduce the exact conditions;
c. Inconsistent CI/CD: Different CI runs may have different outcomes;
d. Time Wasted: Developers spend time debugging issues that are hard to replicate.

(Im not saying these problems are happening, but they can happen.)

### Solution

Set a global random seed right after imports in the test file.

### Benefits

a. Reproducibility: All test runs will use the same random values;
b. Easier Debugging: When a test fails, we can easily reproduce the issue;
c. Consistent CI/CD: Every CI run will have the same behavior;
d. Clear Intent: It's immediately obvious that we're using controlled randomness;
e. Time Saved: Less time spent on debugging non-deterministic test failures.