### PR TITLE
Switch back to using select.select by default 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 2.11.1
+--------------
+- Switch back to using select.select by default [#140].
+
 Version 2.11.0
 --------------
 - Added Python 3.13 support.

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,10 @@ AMQPStorm is a library designed to be consistent, stable and thread-safe.
 Changelog
 =========
 
+Version 2.11.1
+--------------
+- Switch back to using select.select by default [#140].
+
 Version 2.11.0
 --------------
 - Added Python 3.13 support.

--- a/amqpstorm/__init__.py
+++ b/amqpstorm/__init__.py
@@ -1,5 +1,5 @@
 """AMQPStorm."""
-__version__ = '2.11.0'  # noqa
+__version__ = '2.11.1'  # noqa
 __author__ = 'eandersson'  # noqa
 
 import logging

--- a/amqpstorm/compatibility.py
+++ b/amqpstorm/compatibility.py
@@ -40,14 +40,6 @@ class DummyException(Exception):
     """
 
 
-def get_default_poller():
-    if hasattr(select, 'poll'):
-        return 'poll'
-    return 'select'
-
-
-DEFAULT_POLLER = get_default_poller()
-
 SSL_CERT_MAP = {}
 SSL_VERSIONS = {}
 SSL_OPTIONS = [

--- a/amqpstorm/compatibility.py
+++ b/amqpstorm/compatibility.py
@@ -1,6 +1,5 @@
 """Python 2/3 Compatibility layer."""
 
-import select
 import sys
 
 try:

--- a/amqpstorm/connection.py
+++ b/amqpstorm/connection.py
@@ -63,7 +63,7 @@ class Connection(Stateful):
     :param bool ssl: Enable SSL
     :param dict ssl_options: SSL kwargs
     :param dict client_properties: None or dict of client properties
-    :param str poller: select or poll
+    :param str poller: Either "select" or "poll". If you encounter file descriptor errors, consider switching to "poll".
     :param bool lazy: Lazy initialize the connection
 
     :raises AMQPConnectionError: Raises if the connection
@@ -87,7 +87,7 @@ class Connection(Stateful):
             'ssl': kwargs.get('ssl', False),
             'ssl_options': kwargs.get('ssl_options', {}),
             'client_properties': kwargs.get('client_properties', {}),
-            'poller': kwargs.get('poller', compatibility.DEFAULT_POLLER),
+            'poller': 'select'
         }
         self._validate_parameters()
         self._io = IO(self.parameters, exceptions=self._exceptions,

--- a/amqpstorm/connection.py
+++ b/amqpstorm/connection.py
@@ -87,7 +87,7 @@ class Connection(Stateful):
             'ssl': kwargs.get('ssl', False),
             'ssl_options': kwargs.get('ssl_options', {}),
             'client_properties': kwargs.get('client_properties', {}),
-            'poller': 'select'
+            'poller': kwargs.get('poller', 'select'),
         }
         self._validate_parameters()
         self._io = IO(self.parameters, exceptions=self._exceptions,

--- a/amqpstorm/uri_connection.py
+++ b/amqpstorm/uri_connection.py
@@ -85,7 +85,7 @@ class UriConnection(Connection):
             'heartbeat': int(kwargs.pop('heartbeat',
                                         [DEFAULT_HEARTBEAT_TIMEOUT])[0]),
             'poller': kwargs.pop('poller',
-                                 [compatibility.DEFAULT_POLLER])[0],
+                                 ['select'])[0],
             'timeout': int(kwargs.pop('timeout',
                                       [DEFAULT_SOCKET_TIMEOUT])[0])
         }


### PR DESCRIPTION
We are switching back to select.select by default as a user reported performance issues reported in #140. This will still allow advanced users to switch to select.poll when running large deployments.