### PR TITLE
Fix tests breaking under RabbitMQ 4.3

### DIFF
--- a/amqpstorm/tests/functional/management/test_basic.py
+++ b/amqpstorm/tests/functional/management/test_basic.py
@@ -12,7 +12,7 @@ class ApiBasicFunctionalTests(TestFunctionalFramework):
     def test_api_basic_publish(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
 
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
         try:
             self.assertEqual(api.basic.publish(self.message, self.queue_name),
                              {'routed': True})
@@ -23,7 +23,7 @@ class ApiBasicFunctionalTests(TestFunctionalFramework):
     def test_api_basic_get_message(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
 
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
         self.assertEqual(api.basic.publish(self.message, self.queue_name),
                          {'routed': True})
 
@@ -39,7 +39,7 @@ class ApiBasicFunctionalTests(TestFunctionalFramework):
     def test_api_basic_get_message_requeue(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
 
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
         self.assertEqual(api.basic.publish(self.message, self.queue_name),
                          {'routed': True})
 
@@ -55,7 +55,7 @@ class ApiBasicFunctionalTests(TestFunctionalFramework):
     def test_api_basic_get_message_to_dict(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
 
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
         self.assertEqual(api.basic.publish(self.message, self.queue_name),
                          {'routed': True})
 

--- a/amqpstorm/tests/functional/management/test_queue.py
+++ b/amqpstorm/tests/functional/management/test_queue.py
@@ -11,7 +11,7 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
     @setup(queue=False)
     def test_api_queue_get(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
 
         queue = api.queue.get(self.queue_name)
 
@@ -23,7 +23,7 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
     def test_api_queue_list(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
 
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
 
         queues = api.queue.list()
 
@@ -45,9 +45,9 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
         api.virtual_host.create(self.queue_name)
 
         try:
-            api.queue.declare('abc', virtual_host=self.queue_name)
-            api.queue.declare('def', virtual_host=self.queue_name)
-            api.queue.declare('ghi', virtual_host=self.queue_name)
+            api.queue.declare('abc', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('def', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('ghi', durable=True, virtual_host=self.queue_name)
 
             queues = api.queue.list(page_size=1, virtual_host=self.queue_name)
         finally:
@@ -65,9 +65,9 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
         api.virtual_host.create(self.queue_name)
 
         try:
-            api.queue.declare('abc', virtual_host=self.queue_name)
-            api.queue.declare('def', virtual_host=self.queue_name)
-            api.queue.declare('ghi', virtual_host=self.queue_name)
+            api.queue.declare('abc', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('def', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('ghi', durable=True, virtual_host=self.queue_name)
 
             queues = api.queue.list(
                 page_size=None, virtual_host=self.queue_name
@@ -87,9 +87,9 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
         api.virtual_host.create(self.queue_name)
 
         try:
-            api.queue.declare('abc', virtual_host=self.queue_name)
-            api.queue.declare('def', virtual_host=self.queue_name)
-            api.queue.declare('ghi', virtual_host=self.queue_name)
+            api.queue.declare('abc', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('def', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('ghi', durable=True, virtual_host=self.queue_name)
 
             queues = api.queue.list(name='^ab', use_regex='true',
                                     virtual_host=self.queue_name)
@@ -108,9 +108,9 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
         api.virtual_host.create(self.queue_name)
 
         try:
-            api.queue.declare('abc', virtual_host=self.queue_name)
-            api.queue.declare('def', virtual_host=self.queue_name)
-            api.queue.declare('ghi', virtual_host=self.queue_name)
+            api.queue.declare('abc', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('def', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('ghi', durable=True, virtual_host=self.queue_name)
 
             queues = api.queue.list(name='^ab', use_regex=True,
                                     virtual_host=self.queue_name)
@@ -129,9 +129,9 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
         api.virtual_host.create(self.queue_name)
 
         try:
-            api.queue.declare('abc', virtual_host=self.queue_name)
-            api.queue.declare('def', virtual_host=self.queue_name)
-            api.queue.declare('ghi', virtual_host=self.queue_name)
+            api.queue.declare('abc', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('def', durable=True, virtual_host=self.queue_name)
+            api.queue.declare('ghi', durable=True, virtual_host=self.queue_name)
 
             queues = api.queue.list(name='ab', use_regex=False,
                                     virtual_host=self.queue_name)
@@ -148,7 +148,7 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
     def test_api_queue_list_all(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
 
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
 
         queues = api.queue.list(show_all=True)
 
@@ -194,7 +194,7 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
     @setup(new_connection=False)
     def test_api_queue_declare_passive_exists(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
 
         self.assertIsNotNone(api.queue.declare(self.queue_name, passive=True))
 
@@ -216,7 +216,7 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
     def test_api_queue_purge(self):
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
 
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
         self.assertIsNone(api.queue.purge(self.queue_name))
 
     @setup(queue=True)
@@ -224,7 +224,7 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
         exchange_name = 'amq.direct'
 
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
 
         bindings = len(api.queue.bindings(self.queue_name))
 
@@ -242,7 +242,7 @@ class ApiQueueFunctionalTests(TestFunctionalFramework):
 
         api = ManagementApi(HTTP_URL, USERNAME, PASSWORD)
 
-        api.queue.declare(self.queue_name)
+        api.queue.declare(self.queue_name, durable=True)
 
         bindings = len(api.queue.bindings(self.queue_name))
 

--- a/amqpstorm/tests/functional/ssl/test_reliability.py
+++ b/amqpstorm/tests/functional/ssl/test_reliability.py
@@ -59,7 +59,7 @@ class SSLReliabilityFunctionalTests(TestFunctionalFramework):
             # Make sure that it's a new channel.
             self.assertEqual(int(self.channel), 1)
 
-            self.channel.queue.declare(self.queue_name)
+            self.channel.queue.declare(self.queue_name, durable=True)
 
             # Verify that the Connection/Channel has been opened properly.
             self.assertIsNotNone(self.connection._io.socket)
@@ -98,7 +98,7 @@ class SSLReliabilityFunctionalTests(TestFunctionalFramework):
             # Make sure that it's a new channel.
             self.assertEqual(int(channel), 1)
 
-            channel.queue.declare(self.queue_name)
+            channel.queue.declare(self.queue_name, durable=True)
 
             channel.close()
 
@@ -276,7 +276,7 @@ class PublishAndConsume1kWithSSLTest(TestFunctionalFramework):
             ssl_options=ssl_options)
 
         self.channel = self.connection.channel()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         publish_thread = threading.Thread(target=self.publish_messages, )
         publish_thread.daemon = True
@@ -329,7 +329,7 @@ class Consume1kWithSSLUntilEmpty(TestFunctionalFramework):
             ssl_options=ssl_options)
 
         self.channel = self.connection.channel()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         self.publish_messages()
 

--- a/amqpstorm/tests/functional/test_basic.py
+++ b/amqpstorm/tests/functional/test_basic.py
@@ -10,7 +10,7 @@ class BasicFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_basic_get(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         message = self.channel.basic.get(self.queue_name)
@@ -19,14 +19,14 @@ class BasicFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_basic_get_empty(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         message = self.channel.basic.get(self.queue_name)
         self.assertIsNone(message)
 
     @setup(queue=True)
     def test_functional_basic_cancel(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         consumer_tag = self.channel.basic.consume(None, self.queue_name)
 
         result = self.channel.basic.cancel(consumer_tag)
@@ -34,14 +34,14 @@ class BasicFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_basic_recover(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         self.assertFalse(self.channel.basic.recover(requeue=True))
 
     @setup(queue=True)
     def test_functional_basic_ack(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         message = self.channel.basic.get(self.queue_name)
@@ -55,7 +55,7 @@ class BasicFunctionalTests(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_basic_ack_multiple(self):
         message = None
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         for _ in range(5):
             self.channel.basic.publish(self.message, self.queue_name)
@@ -75,7 +75,7 @@ class BasicFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_basic_nack(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         message = self.channel.basic.get(self.queue_name)
@@ -92,7 +92,7 @@ class BasicFunctionalTests(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_basic_nack_multiple(self):
         message = None
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         for _ in range(5):
             self.channel.basic.publish(self.message, self.queue_name)
@@ -112,7 +112,7 @@ class BasicFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_basic_nack_requeue(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         message = self.channel.basic.get(self.queue_name)
@@ -128,7 +128,7 @@ class BasicFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_basic_reject(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         message = self.channel.basic.get(self.queue_name)
@@ -144,7 +144,7 @@ class BasicFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_basic_reject_requeue(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         message = self.channel.basic.get(self.queue_name)

--- a/amqpstorm/tests/functional/test_generic.py
+++ b/amqpstorm/tests/functional/test_generic.py
@@ -15,7 +15,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_get_five_messages(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         # Publish 5 Messages.
         for _ in range(5):
@@ -33,7 +33,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_get_five_empty_messages(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         # Publish 5 Messages.
         for _ in range(5):
@@ -56,7 +56,7 @@ class GenericTest(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_publish_and_get_a_large_message(self):
         self.channel.confirm_deliveries()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         body = self.message * 65536
 
@@ -70,7 +70,7 @@ class GenericTest(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_publish_5_large_messages_and_consume(self):
         self.channel.confirm_deliveries()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         body = self.message * 8192
         messages_to_publish = 5
@@ -92,7 +92,7 @@ class GenericTest(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_publish_5_empty_messages(self):
         self.channel.confirm_deliveries()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         body = b''
         messages_to_publish = 5
@@ -114,7 +114,7 @@ class GenericTest(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_publish_5_large_messages_and_get(self):
         self.channel.confirm_deliveries()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         body = self.message * 8192
         messages_to_publish = 5
@@ -135,7 +135,7 @@ class GenericTest(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_publish_with_properties_and_get(self):
         self.channel.confirm_deliveries()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         app_id = 'travis-ci'
         properties = {
@@ -185,7 +185,7 @@ class GenericTest(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_publish_and_change_app_id(self):
         self.channel.confirm_deliveries()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         message = Message.create(self.channel,
                                  body=self.message)
         message.app_id = 'travis-ci'
@@ -221,7 +221,7 @@ class GenericTest(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_publish_and_consume_five_messages(self):
         self.channel.confirm_deliveries()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         for _ in range(5):
             self.channel.basic.publish(body=self.message,
@@ -251,7 +251,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_generator_consume(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         for _ in range(5):
             self.channel.basic.publish(body=self.message,
@@ -274,7 +274,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_consume_with_custom_message_impl(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         for _ in range(5):
             self.channel.basic.publish(body=self.message,
@@ -302,7 +302,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_consume_and_redeliver(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         self.channel.basic.publish(body=self.message,
                                    routing_key=self.queue_name)
@@ -349,7 +349,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_redelivered(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         self.channel.confirm_deliveries()
         self.channel.basic.publish(body=self.message,
@@ -384,7 +384,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_get_and_redeliver(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         self.channel.confirm_deliveries()
         self.channel.basic.publish(body=self.message,
@@ -404,7 +404,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_get(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         self.channel.basic.publish(body=self.message,
                                    routing_key=self.queue_name)
@@ -416,7 +416,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_get_with_custom_message_impl(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         self.channel.basic.publish(body=self.message,
                                    routing_key=self.queue_name)
@@ -432,7 +432,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_get_auto_decode(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         self.channel.basic.publish(body=self.message,
                                    routing_key=self.queue_name)
@@ -444,7 +444,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_consume_auto_decode(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         self.channel.basic.publish(body=self.message,
                                    routing_key=self.queue_name)
@@ -465,7 +465,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_consume(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         self.channel.basic.publish(body=self.message,
                                    routing_key=self.queue_name)
@@ -486,7 +486,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_confirm(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
 
         self.channel.basic.publish(body=self.message,
@@ -520,7 +520,7 @@ class GenericTest(TestFunctionalFramework):
             self.assertTrue(self.channel.is_open)
             self.assertEqual(why.error_code, 312)
             if why.error_code == 312:
-                self.channel.queue.declare(self.queue_name)
+                self.channel.queue.declare(self.queue_name, durable=True)
 
         result = self.channel.basic.publish(
             body=self.message,
@@ -535,7 +535,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_fail_recover(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
 
         message = Message.create(self.channel, self.message)
@@ -545,7 +545,7 @@ class GenericTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_start_stop_consumer(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
 
         for _ in range(5):

--- a/amqpstorm/tests/functional/test_legacy.py
+++ b/amqpstorm/tests/functional/test_legacy.py
@@ -11,7 +11,7 @@ class LegacyFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_start_stop_consumer_tuple(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
 
         for _ in range(5):
@@ -44,7 +44,7 @@ class LegacyFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_consume_five_messages_tuple(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
 
         for _ in range(5):
@@ -76,7 +76,7 @@ class LegacyFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_generator_consume(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         for _ in range(5):
             self.channel.basic.publish(body=self.message,
@@ -103,7 +103,7 @@ class LegacyFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_get_five_messages(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         # Publish 5 Messages.
         for _ in range(5):

--- a/amqpstorm/tests/functional/test_queue.py
+++ b/amqpstorm/tests/functional/test_queue.py
@@ -24,7 +24,7 @@ class QueueFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_queue_delete(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.queue.delete(self.queue_name,
                                   if_unused=True)
         self.assertRaises(amqpstorm.AMQPChannelError,
@@ -34,7 +34,7 @@ class QueueFunctionalTests(TestFunctionalFramework):
     @setup(queue=True)
     def test_functional_queue_purge(self):
         messages_to_send = 10
-        self.channel.queue.declare(self.queue_name, auto_delete=True)
+        self.channel.queue.declare(self.queue_name, durable=True, auto_delete=True)
         for _ in range(messages_to_send):
             self.channel.basic.publish(self.message, self.queue_name)
         result = self.channel.queue.purge(self.queue_name)

--- a/amqpstorm/tests/functional/test_reliability.py
+++ b/amqpstorm/tests/functional/test_reliability.py
@@ -28,7 +28,7 @@ class ReliabilityFunctionalTests(TestFunctionalFramework):
             # Make sure that it's a new channel.
             self.assertEqual(int(self.channel), 1)
 
-            self.channel.queue.declare(self.queue_name)
+            self.channel.queue.declare(self.queue_name, durable=True)
 
             # Verify that the Connection/Channel has been opened properly.
             self.assertIsNotNone(self.connection._io.socket)
@@ -55,7 +55,7 @@ class ReliabilityFunctionalTests(TestFunctionalFramework):
             # Make sure that it's a new channel.
             self.assertEqual(int(channel), 1)
 
-            channel.queue.declare(self.queue_name)
+            channel.queue.declare(self.queue_name, durable=True)
 
             channel.close()
 
@@ -217,7 +217,7 @@ class ReliabilityFunctionalTests(TestFunctionalFramework):
         self.channel = self.connection.channel()
         self.assertEqual(int(self.channel), 1)
 
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         self.channel.close()
         self.connection.close()
@@ -253,7 +253,7 @@ class PublishAndConsume1kTest(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_consume_1k_messages(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
 
         publish_thread = threading.Thread(target=self.publish_messages, )
         publish_thread.daemon = True
@@ -291,7 +291,7 @@ class Consume1kUntilEmpty(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_publish_and_consume_until_empty(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.confirm_deliveries()
         self.publish_messages()
 

--- a/amqpstorm/tests/functional/test_tx.py
+++ b/amqpstorm/tests/functional/test_tx.py
@@ -19,7 +19,7 @@ class TxFunctionalTests(TestFunctionalFramework):
     def test_functional_tx_commit(self):
         self.channel.tx.select()
 
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         # Sleep for 0.1s to make sure RabbitMQ has time to catch up.
@@ -39,7 +39,7 @@ class TxFunctionalTests(TestFunctionalFramework):
     def test_functional_tx_commit_multiple(self):
         self.channel.tx.select()
 
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         for _ in range(10):
             self.channel.basic.publish(self.message, self.queue_name)
 
@@ -69,7 +69,7 @@ class TxFunctionalTests(TestFunctionalFramework):
     def test_functional_tx_rollback(self):
         self.channel.tx.select()
 
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.basic.publish(self.message, self.queue_name)
 
         self.channel.tx.rollback()
@@ -82,7 +82,7 @@ class TxFunctionalTests(TestFunctionalFramework):
     def test_functional_tx_rollback_multiple(self):
         self.channel.tx.select()
 
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         for _ in range(10):
             self.channel.basic.publish(self.message, self.queue_name)
 

--- a/amqpstorm/tests/functional/test_web_based.py
+++ b/amqpstorm/tests/functional/test_web_based.py
@@ -17,7 +17,7 @@ class WebFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_consume_web_message(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.api.basic.publish(body=self.message,
                                routing_key=self.queue_name)
 
@@ -30,7 +30,7 @@ class WebFunctionalTests(TestFunctionalFramework):
 
     @setup(queue=True)
     def test_functional_remove_queue_while_consuming(self):
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         for _ in range(10):
             self.api.basic.publish(body=self.message,
                                    routing_key=self.queue_name)
@@ -57,7 +57,7 @@ class WebFunctionalTests(TestFunctionalFramework):
                                      virtual_host=self.virtual_host_name,
                                      timeout=1)
         self.channel = self.connection.channel()
-        self.channel.queue.declare(self.queue_name)
+        self.channel.queue.declare(self.queue_name, durable=True)
         self.channel.queue.delete(self.queue_name)
         self.api.user.delete_permission(USERNAME, self.virtual_host_name)
         self.api.virtual_host.delete(self.virtual_host_name)


### PR DESCRIPTION
Beginning with RabbitMQ 4.3.0, non-durable (transient) and non-exclusive queues are no longer permitted. This pull request modifies all tests to default to durable queues as a workaround, as I cannot safely change the defaults for these methods without potentially breaking upstream code.
https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0