### PR TITLE
Fix race condition shutting down socket

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Version 3.1.1
+-------------
+- Connection close is now resilient to ``IO.socket`` being cleared
+  partway through ``_close_socket``; the socket reference is captured
+  once and reused for the shutdown/close calls.
+
 Version 3.1
 -----------
 - Added inline type hints across the public API and shipped ``py.typed``

--- a/amqpstorm/io.py
+++ b/amqpstorm/io.py
@@ -187,18 +187,19 @@ class IO:
 
         :return:
         """
-        if not self.socket:
+        sock = self.socket
+        if sock is None:
             return
         try:
             if self.poller:
                 self.poller.close()
             if self.use_ssl:
-                self.socket.unwrap()  # type: ignore[attr-defined]
-            self.socket.shutdown(socket.SHUT_RDWR)
+                sock.unwrap()  # type: ignore[attr-defined]
+            sock.shutdown(socket.SHUT_RDWR)
         except (OSError, ValueError):
             pass
 
-        self.socket.close()
+        sock.close()
 
     def _get_socket_addresses(self) -> list[Any]:
         """Get Socket address information.

--- a/amqpstorm/tests/unit/io/test_io_exception.py
+++ b/amqpstorm/tests/unit/io/test_io_exception.py
@@ -25,6 +25,23 @@ class IOExceptionTests(TestFramework):
         io.socket.shutdown.side_effect = OSError()
         io._close_socket()
 
+    def test_io_close_socket_nullified_mid_call(self):
+        connection = FakeConnection()
+
+        io = IO(connection.parameters)
+        io._exceptions = []
+        sock = mock.Mock(name='socket', spec=socket.socket)
+
+        def clear_socket(*_):
+            io.socket = None
+
+        sock.shutdown.side_effect = clear_socket
+        io.socket = sock
+
+        io._close_socket()
+
+        sock.close.assert_called_once()
+
     def test_io_receive_raises_socket_error(self):
         connection = FakeConnection()
 


### PR DESCRIPTION
Connection close is now resilient to ``IO.socket`` being cleared partway through ``_close_socket``; the socket reference is captured once and reused for the shutdown/close calls.