### PR TITLE
Fix large-message consume throughput regression in build_inbound_messages

### DIFF
--- a/amqpstorm/channel.py
+++ b/amqpstorm/channel.py
@@ -156,11 +156,14 @@ class Channel(BaseChannel):
         :param bool break_on_empty: Should we break the loop when there are
                                     no more messages in our inbound queue.
 
-                                    To avoid breaking out while messages are
-                                    still in flight from RabbitMQ, the loop
-                                    only exits after the inbound queue has
-                                    been continuously empty for at least one
-                                    second.
+                                    While a consumer is active, to avoid
+                                    breaking out while messages are still in
+                                    flight from RabbitMQ, the loop only exits
+                                    after the inbound queue has been
+                                    continuously empty for at least one
+                                    second. With no active consumer there is
+                                    nothing in flight, so the loop breaks as
+                                    soon as the queue is empty.
         :param bool to_tuple: Should incoming messages be converted to a
                               tuple before delivery.
         :param bool auto_decode: Auto-decode strings when possible.
@@ -205,6 +208,8 @@ class Channel(BaseChannel):
                     raise
                 time.sleep(IDLE_WAIT)
                 if break_on_empty and not self._inbound:
+                    if not self.consumer_tags:
+                        break
                     if empty_since is None:
                         empty_since = time.monotonic()
                     elif time.monotonic() - empty_since >= 1.0:

--- a/amqpstorm/tests/unit/channel/test_channel_message_handling.py
+++ b/amqpstorm/tests/unit/channel/test_channel_message_handling.py
@@ -207,6 +207,8 @@ class ChannelBuildMessageTests(TestFramework):
         channel = Channel(0, FakeConnection(), 360)
         channel.set_state(Channel.OPEN)
         channel._inbound = collections.deque()
+        # An active consumer keeps the empty-timer in effect.
+        channel.add_consumer_tag('travis-ci')
 
         monotonic = mock.Mock(side_effect=[0.0, 1.5])
 
@@ -225,6 +227,8 @@ class ChannelBuildMessageTests(TestFramework):
         channel = Channel(0, FakeConnection(), 360)
         channel.set_state(Channel.OPEN)
         channel._inbound = collections.deque()
+        # An active consumer keeps the empty-timer in effect.
+        channel.add_consumer_tag('travis-ci')
 
         message = self.message.encode('utf-8')
         message_len = len(message)

--- a/amqpstorm/tests/unit/channel/test_channel_message_handling.py
+++ b/amqpstorm/tests/unit/channel/test_channel_message_handling.py
@@ -255,6 +255,30 @@ class ChannelBuildMessageTests(TestFramework):
         self.assertIsInstance(messages[0], Message)
         self.assertEqual(monotonic.call_count, 3)
 
+    def test_channel_build_inbound_messages_break_on_empty_no_consumer_breaks(
+        self,
+    ):
+        channel = Channel(0, FakeConnection(), 360)
+        channel.set_state(Channel.OPEN)
+        channel._inbound = collections.deque()
+
+        # With no active consumer there is nothing in flight from RabbitMQ,
+        # so break_on_empty must break immediately instead of waiting on the
+        # empty-timer.
+        self.assertEqual(channel.consumer_tags, [])
+
+        monotonic = mock.Mock(side_effect=[0.0, 1.5])
+
+        with mock.patch('amqpstorm.channel.time.monotonic', monotonic), \
+                mock.patch('amqpstorm.channel.time.sleep'):
+            messages = list(
+                channel.build_inbound_messages(break_on_empty=True)
+            )
+
+        self.assertEqual(messages, [])
+        # The empty-timer must not be consulted when there is no consumer.
+        monotonic.assert_not_called()
+
     def test_channel_build_no_message_but_inbound_not_empty(self):
         channel = Channel(0, FakeConnection(), 360)
         channel.set_state(Channel.OPEN)


### PR DESCRIPTION
Fixes #153.

## What

`Channel.build_inbound_messages(break_on_empty=True)` waits up to one second on
an empty inbound queue before breaking, even when no consumer is active.
`start_consuming()` therefore pays a fixed ~1 s tail every time the queue drains,
which makes large-body consume ~10× slower than 3.0.x. Full analysis,
measurements and a reproducer are in #153.

## Change

Break immediately when there is no active consumer; keep the one-second grace
introduced in `84e41b7` only while a consumer is subscribed:

```python
if break_on_empty and not self._inbound:
    if not self.consumer_tags:
        break
    if empty_since is None:
        empty_since = time.monotonic()
    elif time.monotonic() - empty_since >= 1.0:
        break
continue
```

- While a consumer is subscribed the behaviour is unchanged from 3.1.0 (that code
  path is untouched), so the premature-break scenario `84e41b7` targeted is
  preserved.
- `consumer_tags` is maintained by the normal API (`basic.consume` adds,
  `stop_consuming` / cancel removes), so no other changes are needed.
- With no consumer the behaviour matches pre-3.0.x (immediate break).

## Tests

- New regression test: with `break_on_empty`, an empty queue and no active
  consumer, the loop breaks immediately without consulting the empty-timer.
- The two existing `break_on_empty` timer tests now register a consumer so they
  keep exercising the active-consumer grace path (`timer_resets` still verifies a
  refilled queue is not abandoned prematurely).

## Verification

- Repro restores large-body consume to ~3.0.x throughput (~112 → ~1030–1250
  MB/s).
- `pytest amqpstorm/tests/unit`: all green; `flake8` clean.
- Real-broker post-cancel in-flight check: the fix delivers exactly what the
  broker pushed and loses nothing vs 3.1.0 / 3.0.x in the tested conditions
  (details and both reproducers in #153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
