### PR TITLE
Validate empty_timeout, fix its docstring, and add tests (follow-up to #155)

### DIFF
--- a/amqpstorm/channel.py
+++ b/amqpstorm/channel.py
@@ -171,11 +171,12 @@ class Channel(BaseChannel):
         :param class message_impl: Optional message class to use, derived from
                                    BaseMessage, for created messages. Defaults
                                    to Message.
-        :param float,None empty_timeout: How long, in seconds, the inbound
+        :param int,float,None empty_timeout: How long, in seconds, the inbound
                                     queue must stay continuously empty before
                                     ``break_on_empty`` exits the loop while a
-                                    consumer is active. A None value exits as
-                                    soon as the queue is empty, without waiting.
+                                    consumer is active. A falsy value (``None``
+                                    or ``0``) exits as soon as the queue is
+                                    empty, without waiting.
         :raises AMQPInvalidArgument: Invalid Parameters
         :raises AMQPChannelError: Raises if the channel encountered an error.
         :raises AMQPConnectionError: Raises if the connection
@@ -196,6 +197,15 @@ class Channel(BaseChannel):
                 )
         else:
             message_impl = Message
+        if empty_timeout is not None:
+            # Reject bool (an int subclass) and NaN (which fails ``>= 0``).
+            is_bool = isinstance(empty_timeout, bool)
+            is_number = isinstance(empty_timeout, (int, float))
+            valid = not is_bool and is_number and empty_timeout >= 0
+            if not valid:
+                raise AMQPInvalidArgument(
+                    'empty_timeout must be None or a non-negative number'
+                )
         empty_since = None
         while not self.is_closed:
             try:

--- a/amqpstorm/tests/unit/channel/test_channel_message_handling.py
+++ b/amqpstorm/tests/unit/channel/test_channel_message_handling.py
@@ -10,6 +10,7 @@ from pamqp.body import ContentBody
 from amqpstorm import AMQPChannelError
 from amqpstorm import AMQPConnectionError
 from amqpstorm import Channel
+from amqpstorm import AMQPInvalidArgument
 from amqpstorm import Message
 from amqpstorm.tests.utility import FakeConnection
 from amqpstorm.tests.utility import TestFramework
@@ -336,6 +337,55 @@ class ChannelBuildMessageTests(TestFramework):
             'in-flight message dropped when the consumer was cancelled'
         )
         self.assertEqual(messages[0].body, self.message)
+
+    def test_channel_build_inbound_messages_empty_timeout_falsy_breaks(self):
+        # A falsy empty_timeout (None or 0) exits as soon as the queue is
+        # empty; the timer is never consulted, even with an active consumer.
+        for empty_timeout in (None, 0):
+            channel = Channel(0, FakeConnection(), 360)
+            channel.set_state(Channel.OPEN)
+            channel._inbound = collections.deque()
+            channel.add_consumer_tag('travis-ci')
+
+            monotonic = mock.Mock(side_effect=[0.0, 1.5])
+
+            with mock.patch('amqpstorm.channel.time.monotonic', monotonic), \
+                    mock.patch('amqpstorm.channel.time.sleep'):
+                messages = list(
+                    channel.build_inbound_messages(break_on_empty=True,
+                                                   empty_timeout=empty_timeout)
+                )
+
+            self.assertEqual(messages, [])
+            monotonic.assert_not_called()
+
+    def test_channel_build_inbound_messages_empty_timeout_custom_value(self):
+        channel = Channel(0, FakeConnection(), 360)
+        channel.set_state(Channel.OPEN)
+        channel._inbound = collections.deque()
+        channel.add_consumer_tag('travis-ci')
+
+        monotonic = mock.Mock(side_effect=[0.0, 0.6])
+
+        with mock.patch('amqpstorm.channel.time.monotonic', monotonic), \
+                mock.patch('amqpstorm.channel.time.sleep'):
+            messages = list(
+                channel.build_inbound_messages(break_on_empty=True,
+                                               empty_timeout=0.5)
+            )
+
+        self.assertEqual(messages, [])
+        # Two observations: start the timer, then confirm the threshold passed.
+        self.assertEqual(monotonic.call_count, 2)
+
+    def test_channel_build_inbound_messages_invalid_empty_timeout(self):
+        channel = Channel(0, FakeConnection(), 360)
+        channel.set_state(Channel.OPEN)
+
+        # non-numeric, negative, bool (int subclass), and NaN are all invalid.
+        for bad in ('soon', -1, True, float('nan')):
+            with self.assertRaises(AMQPInvalidArgument):
+                list(channel.build_inbound_messages(empty_timeout=bad))
 
     def test_channel_build_inbound_messages(self):
         channel = Channel(0, FakeConnection(), 360)


### PR DESCRIPTION
Follow-up to #155 (the `empty_timeout` change, shipped in 3.1.3) — the smaller points left for after merge.

### Changes
- **Validation.** `build_inbound_messages` now raises `AMQPInvalidArgument` when `empty_timeout` is not `None` and not a real, non-negative number. This rejects non-numeric values, `bool` (an `int` subclass), negatives, and `NaN` — the last of which would otherwise make `break_on_empty` never break while a consumer is active (`elapsed >= NaN` is always `False`). Previously such values failed later inside the loop (e.g. `TypeError`) or hung.
- **Docstring.** `empty_timeout` is now typed `int,float,None`, and notes that any falsy value (`None` or `0`) exits immediately, matching the implementation.
- **Tests.** A falsy `empty_timeout` (`None`/`0`) exits immediately without consulting the timer; a custom value waits that long; an invalid value raises `AMQPInvalidArgument`.

Branches off `main` (3.1.3). Unit tests and `flake8` pass locally.
